### PR TITLE
Added GPL licenses

### DIFF
--- a/src/main/java/com/github/oehme/sobula/License.java
+++ b/src/main/java/com/github/oehme/sobula/License.java
@@ -1,27 +1,67 @@
 package com.github.oehme.sobula;
 
+import java.util.regex.Pattern;
+
 public enum License {
 	EPL_V1_0(
 		"EPL-1.0", 
 		"Eclipse Public License, Version 1.0", 
-		"http://opensource.org/licenses/EPL-1.0",
-		"Eclipse Public License - v 1.0"
+		"https://www.eclipse.org/legal/epl-v10.html",
+		"Eclipse Public License\\s+-\\s+v 1.0"
 	), 
 	MIT(
 		"MIT", 
 		"The MIT License", 
-		"http://opensource.org/licenses/MIT"
+		"http://opensource.org/licenses/MIT",
+		Pattern.quote(
+			"Permission is hereby granted, free of charge, to any person obtaining a copy\n" +
+	        "of this software and associated documentation files (the \"Software\"), to deal\n" +
+	        "in the Software without restriction, including without limitation the rights\n" +
+	        "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n" +
+	        "copies of the Software, and to permit persons to whom the Software is\n" +
+	        "furnished to do so, subject to the following conditions:")
 	), 
 	APACHE_V2_0(
 		"Apache-2.0", 
 		"Apache License, Version 2.0", 
-		"http://opensource.org/licenses/Apache-2.0"
+		"http://www.apache.org/licenses/LICENSE-2.0",
+		"Apache License\\s+Version 2.0, January 2004"
+	),
+	GPL_V2_0(
+			"GPL-2.0", 
+			"GNU General Public License Version 2, June 1991", 
+			"http://www.gnu.org/licenses/gpl-2.0",
+			"GNU GENERAL PUBLIC LICENSE\\s+Version 2, June 1991"
+	),
+	LGPL_V2_1(
+			"LGPL-2.1", 
+			"GNU Lesser General Public License Version 2.1, February 1999", 
+			"http://www.gnu.org/licenses/lgpl-2.1",
+			"GNU LESSER GENERAL PUBLIC LICENSE\\s+Version 2.1, February 1999"
+	),
+	GPL_V3_0(
+			"GPL-3.0", 
+			"GNU General Public License Version 3, 29 June 2007", 
+			"http://www.gnu.org/licenses/gpl-3.0",
+			"GNU GENERAL PUBLIC LICENSE\\s+Version 3, 29 June 2007"
+	),
+	LGPL_V3_0(
+			"LGPL-3.0", 
+			"GNU Lesser General Public License Version 3, 29 June 2007", 
+			"http://www.gnu.org/licenses/lgpl-3.0",
+			"GNU LESSER GENERAL PUBLIC LICENSE\\s+Version 3, 29 June 2007"
+	),
+	AGPL_V3_0(
+			"AGPL-3.0", 
+			"GNU Affero General Public License Version 3, 19 November 2007", 
+			"http://www.gnu.org/licenses/agpl-3.0.html",
+			"GNU AFFERO GENERAL PUBLIC LICENSE\\s+Version 3, 19 November 2007"
 	);
 	
 	private String id;
 	private String longName;
 	private String url;
-	private String[] aliaes;
+	private String[] recognitionPatterns;
 	
 	public String getId() {
 		return id;
@@ -38,18 +78,19 @@ public enum License {
 	public boolean matches(String licenseText) {
 		if (licenseText.contains(longName))
 			return true;
-		for (String alias : aliaes) {
-			if (licenseText.contains(alias))
+		for (String recognitionPattern : recognitionPatterns) {
+			Pattern pattern = Pattern.compile(recognitionPattern);
+			if (pattern.matcher(licenseText).find())
 				return true;
 		}
 		return false;
 		
 	}
 
-	private License(String id, String longName, String url, String... aliases) {
+	private License(String id, String longName, String url, String... recognitionPatterns) {
 		this.id = id;
 		this.longName = longName;
 		this.url = url;
-		this.aliaes = aliases;
+		this.recognitionPatterns = recognitionPatterns;
 	}
 }

--- a/src/main/java/com/github/oehme/sobula/License.java
+++ b/src/main/java/com/github/oehme/sobula/License.java
@@ -19,7 +19,18 @@ public enum License {
 	        "in the Software without restriction, including without limitation the rights\n" +
 	        "to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n" +
 	        "copies of the Software, and to permit persons to whom the Software is\n" +
-	        "furnished to do so, subject to the following conditions:")
+	        "furnished to do so, subject to the following conditions:\n" + 
+	        "\n\n" +
+	        "The above copyright notice and this permission notice shall be included in\n" +
+	        "all copies or substantial portions of the Software.\n" +
+	        "\n\n" +
+	        "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n" +
+	        "IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n" +
+	        "FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\n" +
+	        "AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n" +
+	        "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n" +
+	        "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n" +
+	        "THE SOFTWARE.")
 	), 
 	APACHE_V2_0(
 		"Apache-2.0", 

--- a/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
+++ b/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Denis Kuniss (http://www.grammarcraft.de).
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+package com.github.oehme.sobula;
+
+import org.junit.Test;
+import static org.junit.Assert.*
+
+/**
+ * @author kuniss@grammarcraft.de
+ */
+public class LicenseTest {
+
+	@Test
+	def void match_Eclipse10_license() {
+	    val licenseText = '''
+            Eclipse Public License - v 1.0
+            
+            THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+            
+            1. DEFINITIONS
+            
+            "Contribution" means:
+            ...
+        '''
+		assertTrue(License.EPL_V1_0.matches(licenseText))
+		
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+		assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+	}
+
+    @Test
+    def void match_Apache20_license() {
+        val licenseText = '''
+                                          Apache License
+                                    Version 2.0, January 2004
+                                 http://www.apache.org/licenses/
+                    
+            TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                    
+            1. Definitions.
+            ...
+        '''
+        assertTrue(License.APACHE_V2_0.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+    @Test
+    def void match_MIT_license() {
+        val licenseText = '''
+            Copyright (c) <year> <copyright holders>
+            
+            
+            Permission is hereby granted, free of charge, to any person obtaining a copy
+            of this software and associated documentation files (the "Software"), to deal
+            in the Software without restriction, including without limitation the rights
+            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+            copies of the Software, and to permit persons to whom the Software is
+            furnished to do so, subject to the following conditions:
+            
+            
+            The above copyright notice and this permission notice shall be included in
+            all copies or substantial portions of the Software.
+            ...
+        '''
+        assertTrue(License.MIT.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+    }
+
+    @Test
+    def void match_LGPL30_license() {
+        val licenseText = '''
+                               GNU LESSER GENERAL PUBLIC LICENSE
+                                   Version 3, 29 June 2007
+            
+             Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+             Everyone is permitted to copy and distribute verbatim copies
+             of this license document, but changing it is not allowed.
+            
+            
+              This version of the GNU Lesser General Public License incorporates
+            the terms and conditions of version 3 of the GNU General Public
+            License, supplemented by the additional permissions listed below.
+            
+              0. Additional Definitions.
+            ...
+        '''
+        assertTrue(License.LGPL_V3_0.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+    @Test
+    def void match_GPL30_license() {
+        val licenseText = '''
+                                GNU GENERAL PUBLIC LICENSE
+                                   Version 3, 29 June 2007
+            
+             Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+             Everyone is permitted to copy and distribute verbatim copies
+             of this license document, but changing it is not allowed.
+            
+                                        Preamble
+            ...
+        '''
+        assertTrue(License.GPL_V3_0.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+
+    @Test
+    def void match_LGPL21_license() {
+        val licenseText = '''
+                              GNU LESSER GENERAL PUBLIC LICENSE
+                                   Version 2.1, February 1999
+            
+             Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+             51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+             Everyone is permitted to copy and distribute verbatim copies
+             of this license document, but changing it is not allowed.
+            
+            [This is the first released version of the Lesser GPL.  It also counts
+             as the successor of the GNU Library Public License, version 2, hence
+             the version number 2.1.]
+            
+                                        Preamble
+            ...
+        '''
+        assertTrue(License.LGPL_V2_1.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+    @Test
+    def void match_GPL20_license() {
+        val licenseText = '''
+                                GNU GENERAL PUBLIC LICENSE
+                                   Version 2, June 1991
+            
+             Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+             51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+             Everyone is permitted to copy and distribute verbatim copies
+             of this license document, but changing it is not allowed.
+            
+                                        Preamble
+            ...
+        '''
+        assertTrue(License.GPL_V2_0.matches(licenseText))
+        
+        assertFalse(License.AGPL_V3_0.matches(licenseText))
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+    @Test
+    def void match_AGPL30_license() {
+        val licenseText = '''
+                                GNU AFFERO GENERAL PUBLIC LICENSE
+                                   Version 3, 19 November 2007
+            
+             Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+             Everyone is permitted to copy and distribute verbatim copies
+             of this license document, but changing it is not allowed.
+            
+                                        Preamble
+            ...
+        '''
+        assertTrue(License.AGPL_V3_0.matches(licenseText))
+        
+        assertFalse(License.APACHE_V2_0.matches(licenseText))
+        assertFalse(License.EPL_V1_0.matches(licenseText))
+        assertFalse(License.GPL_V2_0.matches(licenseText))
+        assertFalse(License.GPL_V3_0.matches(licenseText))
+        assertFalse(License.LGPL_V2_1.matches(licenseText))
+        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertFalse(License.MIT.matches(licenseText))
+    }
+
+}

--- a/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
+++ b/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
@@ -17,7 +17,7 @@ import static org.junit.Assert.*
  */
 public class LicenseTest {
 
-    def assertOnlyMatchedBy(License license, String licenseText) {
+    private def onlyMatchedBy(String licenseText, License license) {
         assertTrue(license.matches(licenseText))
         License.values.filter[it != license].forEach[assertFalse(matches(licenseText))]
     }
@@ -34,7 +34,7 @@ public class LicenseTest {
             "Contribution" means:
             ...
         '''
-        assertOnlyMatchedBy(License.EPL_V1_0, licenseText)
+        licenseText.onlyMatchedBy(License.EPL_V1_0)
 	}
 
     @Test
@@ -49,7 +49,7 @@ public class LicenseTest {
             1. Definitions.
             ...
         '''
-        assertOnlyMatchedBy(License.APACHE_V2_0, licenseText)
+        licenseText.onlyMatchedBy(License.APACHE_V2_0)
     }
 
     @Test
@@ -78,7 +78,7 @@ public class LicenseTest {
             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
             THE SOFTWARE.
         '''
-        assertOnlyMatchedBy(License.MIT, licenseText)
+        licenseText.onlyMatchedBy(License.MIT)
     }
 
     @Test
@@ -99,7 +99,7 @@ public class LicenseTest {
               0. Additional Definitions.
             ...
         '''
-        assertOnlyMatchedBy(License.LGPL_V3_0, licenseText)
+        licenseText.onlyMatchedBy(License.LGPL_V3_0)
     }
 
     @Test
@@ -115,7 +115,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertOnlyMatchedBy(License.GPL_V3_0, licenseText)
+        licenseText.onlyMatchedBy(License.GPL_V3_0)
     }
 
 
@@ -137,7 +137,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertOnlyMatchedBy(License.LGPL_V2_1, licenseText)
+        licenseText.onlyMatchedBy(License.LGPL_V2_1)
     }
 
     @Test
@@ -154,7 +154,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertOnlyMatchedBy(License.GPL_V2_0, licenseText)
+        licenseText.onlyMatchedBy(License.GPL_V2_0)
     }
 
     @Test
@@ -170,7 +170,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertOnlyMatchedBy(License.AGPL_V3_0, licenseText)
+        licenseText.onlyMatchedBy(License.AGPL_V3_0)
     }
 
 }

--- a/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
+++ b/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
@@ -8,13 +8,19 @@
 
 package com.github.oehme.sobula;
 
-import org.junit.Test;
+import org.junit.Test
+
 import static org.junit.Assert.*
 
 /**
  * @author kuniss@grammarcraft.de
  */
 public class LicenseTest {
+
+    def assertOnlyMatchedBy(License license, String licenseText) {
+        assertTrue(license.matches(licenseText))
+        License.values.filter[it != license].forEach[assertFalse(matches(licenseText))]
+    }
 
 	@Test
 	def void match_Eclipse10_license() {
@@ -28,15 +34,7 @@ public class LicenseTest {
             "Contribution" means:
             ...
         '''
-		assertTrue(License.EPL_V1_0.matches(licenseText))
-		
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-		assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.EPL_V1_0, licenseText)
 	}
 
     @Test
@@ -51,15 +49,7 @@ public class LicenseTest {
             1. Definitions.
             ...
         '''
-        assertTrue(License.APACHE_V2_0.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.APACHE_V2_0, licenseText)
     }
 
     @Test
@@ -78,17 +68,17 @@ public class LicenseTest {
             
             The above copyright notice and this permission notice shall be included in
             all copies or substantial portions of the Software.
-            ...
+            
+            
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+            THE SOFTWARE.
         '''
-        assertTrue(License.MIT.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
+        assertOnlyMatchedBy(License.MIT, licenseText)
     }
 
     @Test
@@ -109,15 +99,7 @@ public class LicenseTest {
               0. Additional Definitions.
             ...
         '''
-        assertTrue(License.LGPL_V3_0.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.LGPL_V3_0, licenseText)
     }
 
     @Test
@@ -133,15 +115,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertTrue(License.GPL_V3_0.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.GPL_V3_0, licenseText)
     }
 
 
@@ -163,15 +137,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertTrue(License.LGPL_V2_1.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.LGPL_V2_1, licenseText)
     }
 
     @Test
@@ -188,15 +154,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertTrue(License.GPL_V2_0.matches(licenseText))
-        
-        assertFalse(License.AGPL_V3_0.matches(licenseText))
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.GPL_V2_0, licenseText)
     }
 
     @Test
@@ -212,15 +170,7 @@ public class LicenseTest {
                                         Preamble
             ...
         '''
-        assertTrue(License.AGPL_V3_0.matches(licenseText))
-        
-        assertFalse(License.APACHE_V2_0.matches(licenseText))
-        assertFalse(License.EPL_V1_0.matches(licenseText))
-        assertFalse(License.GPL_V2_0.matches(licenseText))
-        assertFalse(License.GPL_V3_0.matches(licenseText))
-        assertFalse(License.LGPL_V2_1.matches(licenseText))
-        assertFalse(License.LGPL_V3_0.matches(licenseText))
-        assertFalse(License.MIT.matches(licenseText))
+        assertOnlyMatchedBy(License.AGPL_V3_0, licenseText)
     }
 
 }


### PR DESCRIPTION
I've added all actual GPL licenses, for this I replaced license aliases string comparison by pattern matching as it is more flexible regarding user specific formatting which may happen under circumstances;
replaced license web references by the origins of license - should be the origin, not opensource.org/licenses;
MIT license recognition corrected too
