### PR TITLE
Need IBM's Common Public License for a particlar project

### DIFF
--- a/src/main/java/com/github/oehme/sobula/License.java
+++ b/src/main/java/com/github/oehme/sobula/License.java
@@ -95,6 +95,7 @@ public enum License {
 	public boolean matches(String licenseText) {
 		if (licenseText.contains(longName))
 			return true;
+		licenseText = normalizeEOL(licenseText);
 		for (String recognitionPattern : recognitionPatterns) {
 			Pattern pattern = Pattern.compile(recognitionPattern);
 			if (pattern.matcher(licenseText).find())
@@ -102,6 +103,18 @@ public enum License {
 		}
 		return false;
 		
+	}
+	
+	/**
+	 * Normalizes Windows and Mac EOL to Linux EOL.
+	 * @param originalText the original text
+	 * @return the normalized text
+	 */
+	private String normalizeEOL(String originalText) {
+		// for Windows
+		String result = originalText.replaceAll("\\r\\n", "\n");
+		// for Mac
+		return result.replaceAll("\\r", "\n");
 	}
 
 	private License(String id, String longName, String url, String... recognitionPatterns) {

--- a/src/main/java/com/github/oehme/sobula/License.java
+++ b/src/main/java/com/github/oehme/sobula/License.java
@@ -67,6 +67,12 @@ public enum License {
 			"GNU Affero General Public License Version 3, 19 November 2007", 
 			"http://www.gnu.org/licenses/agpl-3.0.html",
 			"GNU AFFERO GENERAL PUBLIC LICENSE\\s+Version 3, 19 November 2007"
+	),
+	CPL_V1_0(
+			"CPL-1.0", 
+			"Common Public License (CPL) -- V1.0", 
+			"http://www.ibm.com/developerworks/library/os-cpl.html",
+			"Common Public License\\s+(\\(CPL\\)\\s+)?(--\\s+)?V1.0"
 	);
 	
 	private String id;

--- a/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
+++ b/src/test/java/com/github/oehme/sobula/LicenseTest.xtend
@@ -173,4 +173,27 @@ public class LicenseTest {
         licenseText.onlyMatchedBy(License.AGPL_V3_0)
     }
 
+    @Test
+    def void match_CPL10_license() {
+        val licenseText = '''
+			Common Public License (CPL) -- V1.0
+			
+			03 May 2005
+			Updated 16 Apr 2009
+			
+			As of 25 Feb 2009, IBM has assigned the Agreement Steward role for the
+			CPL to the Eclipse Foundation. Eclipse has designated the Eclipse Public
+			License (EPL) as the follow-on version of the CPL.
+			
+			
+			Eclipse Foundation CPL
+			
+			THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS COMMON
+			PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF
+			THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+			...
+        '''
+        licenseText.onlyMatchedBy(License.CPL_V1_0)
+    }
+
 }


### PR DESCRIPTION
I would like to add the CPL for applying the sobula Gradle plugin for particular projects where this license is used.

Additionally I corrected a problem regarding EOL on different platforms (Windows, Mac, Linux) when matching license patterns. In fact, the MIT license test failed on Windows. Originally I developed the first enhancement on Linux...

Denis
